### PR TITLE
PSOTK-12 Fix NPE in CreateAuditLogNotification

### DIFF
--- a/src/test/groovy/com/boomi/psotoolkit/core/CreateAuditLogNotificationTests.groovy
+++ b/src/test/groovy/com/boomi/psotoolkit/core/CreateAuditLogNotificationTests.groovy
@@ -162,6 +162,34 @@ class CreateAuditLogNotificationTests extends BaseTests {
 		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_AUDITLOG_SIZE_MAX, "2000");
 		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_DISABLE_NOTIFICATION, "0");
 		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_DISABLE_AUDIT, "0");
+
+		dataContext.getProperties(0).put(DDP_FWK_SORT_TS, "20240802 074619.486");
+		dataContext.getProperties(1).put(DDP_FWK_SORT_TS, "20240802 074637.048");
+		dataContext.getProperties(2).put(DDP_FWK_SORT_TS, "20240802 074639.902");
+
+		dataContext.getProperties(0).put(DDP_FWK_LEVEL, "LOG");
+		dataContext.getProperties(1).put(DDP_FWK_LEVEL, "ERROR");
+		dataContext.getProperties(2).put(DDP_FWK_LEVEL, "LOG");
+
+		new CreateAuditLogNotification(dataContext).execute();
+
+		JsonSlurper jsluper = new JsonSlurper();
+
+		String jsonOut = '{"ProcessContext":{"TrackingId":"134567890","TrackedFields":"name#testit","Container":"1a945e1-bb16-443c-9ef0-d7f91bf342a8","ExecutionId":"e546a65d-52b4-4acb-9577-e368491c7009","API":null,"MainProcessName":"Mock It","MainProcessComponentId":"2466a0cf-2951-4d60-8ef7-548416c414ea","Folder":"Mock/It"},"Auditlogitem":[{"Level":"LOG","Id":"482013909434641342","Timestamp":"20240802 074619.486","Step":"[FWK] SET Context (route)","Details":"","DocType":null,"DocBase64":null},{"Level":"ERROR","Id":"5886728937423444414","Timestamp":"20240802 074637.048","ProcessCallStack":"[FWK] CLOSE Context (route) (inline-test) (Continuation f_0) &gt; [FWK] CREATE Notification (facade)","Step":"Notification","ErrorClass":"TransformationError","Details":"[FWK] CLOSE Context (route) (inline-test) (Continuation f_0) - This is a test error","DocType":"json","DocBase64":"eyJERFBfRG9jdW1lbnRJZCI6IjY4MjUxNzcxNTQ5ODk3MDM3NDciLCJERFBfUHJldmlvdXNFdmVudElkIjoiNTQ0In0="},{"Level":"LOG","Id":"8881144415106398243","Timestamp":"20240802 074639.902","Step":"[FWK] CLOSE Context (route) (Continuation f_0)","Details":"&lt;style&gt; tr:hover {background-color: #D6EEEE;} &lt;/style&gt; &lt;p&gt;&lt;table&gt; &lt;tr&gt; &lt;th&gt;Process Id&lt;/th&gt; &lt;td&gt;0a469ebb-9079-499d-98ac-d5778373fa18&lt;/td&gt; &lt;/tr&gt; &lt;tr&gt; &lt;th&gt;Execution Id&lt;/th&gt; &lt;td&gt;execution-a9a990f3-ff83-4c41-a894-631cee177614-2024.08.02&lt;/td&gt; &lt;/tr&gt; &lt;tr&gt; &lt;th&gt;Duration (ms)&lt;/th&gt; &lt;td&gt;41697&lt;/td&gt; &lt;/tr&gt; &lt;/table&gt;&lt;/p&gt;","DocType":null,"DocBase64":null}]}';
+		String jsonStreamText = dataContext.getOutStreams()[0].getText();
+		assert jsonOut.size() == jsonStreamText.size();
+		def expectedJson = jsluper.parseText(jsonOut);
+		def actualJson = jsluper.parseText(jsonStreamText);
+		assert actualJson == expectedJson;
+	}
+
+	@Test
+	void testFilterSortCombineForceAudit() {
+		def dataContext = setupDataContextFromFolder("src/test/resources/com/boomi/psotoolkit/core/filtersortcreateauditlognotification");
+
+		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_AUDITLOG_SIZE_MAX, "2000");
+		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_DISABLE_NOTIFICATION, "0");
+		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_DISABLE_AUDIT, "1");
 		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_ERROR_LEVEL, "true");
 
 		dataContext.getProperties(0).put(DDP_FWK_SORT_TS, "20240802 074619.486");
@@ -182,5 +210,56 @@ class CreateAuditLogNotificationTests extends BaseTests {
 		def expectedJson = jsluper.parseText(jsonOut);
 		def actualJson = jsluper.parseText(jsonStreamText);
 		assert actualJson == expectedJson;
+	}
+
+	@Test
+	void testFilterSortCombineAuditOnly() {
+		def dataContext = setupDataContextFromFolder("src/test/resources/com/boomi/psotoolkit/core/filtersortcreateauditlognotification");
+
+		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_AUDITLOG_SIZE_MAX, "2000");
+		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_DISABLE_NOTIFICATION, "1");
+		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_DISABLE_AUDIT, "0");
+
+		dataContext.getProperties(0).put(DDP_FWK_SORT_TS, "20240802 074619.486");
+		dataContext.getProperties(1).put(DDP_FWK_SORT_TS, "20240802 074637.048");
+		dataContext.getProperties(2).put(DDP_FWK_SORT_TS, "20240802 074639.902");
+
+		dataContext.getProperties(0).put(DDP_FWK_LEVEL, "LOG");
+		dataContext.getProperties(1).put(DDP_FWK_LEVEL, "ERROR");
+		dataContext.getProperties(2).put(DDP_FWK_LEVEL, "LOG");
+
+		new CreateAuditLogNotification(dataContext).execute();
+
+		JsonSlurper jsluper = new JsonSlurper();
+
+		String jsonOut = '{"ProcessContext":{"TrackingId":"134567890","TrackedFields":"name#testit","Container":"1a945e1-bb16-443c-9ef0-d7f91bf342a8","ExecutionId":"e546a65d-52b4-4acb-9577-e368491c7009","API":null,"MainProcessName":"Mock It","MainProcessComponentId":"2466a0cf-2951-4d60-8ef7-548416c414ea","Folder":"Mock/It"},"Auditlogitem":[{"Level":"LOG","Id":"482013909434641342","Timestamp":"20240802 074619.486","Step":"[FWK] SET Context (route)","Details":"","DocType":null,"DocBase64":null},{"Level":"LOG","Id":"8881144415106398243","Timestamp":"20240802 074639.902","Step":"[FWK] CLOSE Context (route) (Continuation f_0)","Details":"&lt;style&gt; tr:hover {background-color: #D6EEEE;} &lt;/style&gt; &lt;p&gt;&lt;table&gt; &lt;tr&gt; &lt;th&gt;Process Id&lt;/th&gt; &lt;td&gt;0a469ebb-9079-499d-98ac-d5778373fa18&lt;/td&gt; &lt;/tr&gt; &lt;tr&gt; &lt;th&gt;Execution Id&lt;/th&gt; &lt;td&gt;execution-a9a990f3-ff83-4c41-a894-631cee177614-2024.08.02&lt;/td&gt; &lt;/tr&gt; &lt;tr&gt; &lt;th&gt;Duration (ms)&lt;/th&gt; &lt;td&gt;41697&lt;/td&gt; &lt;/tr&gt; &lt;/table&gt;&lt;/p&gt;","DocType":null,"DocBase64":null}]}';
+		String jsonStreamText = dataContext.getOutStreams()[0].getText();
+		assert jsonOut.size() == jsonStreamText.size();
+		def expectedJson = jsluper.parseText(jsonOut);
+		def actualJson = jsluper.parseText(jsonStreamText);
+		assert actualJson == expectedJson;
+	}
+
+	@Test
+	void testFilterSortCombineNoLogging() {
+		def dataContext = setupDataContextFromFolder("src/test/resources/com/boomi/psotoolkit/core/filtersortcreateauditlognotification");
+
+		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_AUDITLOG_SIZE_MAX, "2000");
+		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_DISABLE_NOTIFICATION, "1");
+		ExecutionUtil.dynamicProcessProperties.put(DPP_FWK_DISABLE_AUDIT, "1");
+
+		dataContext.getProperties(0).put(DDP_FWK_SORT_TS, "20240802 074619.486");
+		dataContext.getProperties(1).put(DDP_FWK_SORT_TS, "20240802 074637.048");
+		dataContext.getProperties(2).put(DDP_FWK_SORT_TS, "20240802 074639.902");
+
+		dataContext.getProperties(0).put(DDP_FWK_LEVEL, "LOG");
+		dataContext.getProperties(1).put(DDP_FWK_LEVEL, "LOG");
+		dataContext.getProperties(2).put(DDP_FWK_LEVEL, "LOG");
+
+		new CreateAuditLogNotification(dataContext).execute();
+
+		JsonSlurper jsluper = new JsonSlurper();
+
+		assert dataContext.getOutStreams().isEmpty();
 	}
 }


### PR DESCRIPTION
PSOTK-12
An NPE occurs when the are no error logs and both DPP_FWK_DISABLE_AUDIT and DPP_FWK_DISABLE_NOTIFICATION are set to 1 (YES). In this case no document should be produced.
Add a unit test case.
Refactor - create missed constant string values.